### PR TITLE
fix: lower case commit message action

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -6,6 +6,7 @@
   automerge: true,
   automergeStrategy: "squash",
   automergeType: "pr",
+  commitMessageAction: "update",
   platformAutomerge: true,
   separateMajorMinor: true,
   separateMinorPatch: false,


### PR DESCRIPTION
Le validations de conventional commits préfèrent le lower case