### PR TITLE
Remove v prefix from php package version to fix vv issues

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -21,7 +21,7 @@
     { "matchCategories": ["docker"], "addLabels": ["docker"], "prPriority": 5 },
     { "matchCategories": ["helm"], "addLabels": ["helm"], "automerge": false },
     { "matchCategories": ["java"], "addLabels": ["jvm"] },
-    { 
+    {
       "matchDatasources": ["maven"],
       "registryUrls": [
         "https://repo.maven.apache.org/maven2",
@@ -190,6 +190,11 @@
       "matchCategories": ["php"],
       "matchPackageNames": ["vimeo/psalm"],
       "groupName": "psalm"
+    },
+    {
+      "matchCategories": ["php"],
+      "matchPackagePatterns": ["^kronos/", "^kronostechnologies/","^equisoft/"],
+      "extractVersion": "^v(?<version>.*)$"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Je suis assez confiant que cette règle va régler nos problèmes de vv dans les composer.json.

J'ai fouillé dans le code de renovate et il utilise le datasource `git-tags` qui prends littéralement le nom du tag comme version.

Par contre après il applique la règle `extractVersion`.  J'ai donc fait une règle qui strip les `v`.