### PR TITLE
fix: disable major and minor for mysql docker image

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -57,6 +57,12 @@
 
     {
       "matchCategories": ["docker"],
+      "matchUpdateTypes": ["minor", "major"],
+      "matchPackageNames": ["mysql"],
+      "enabled": false
+    },
+    {
+      "matchCategories": ["docker"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Docker minors and patches",
       "commitMessageExtra": ""
@@ -172,7 +178,7 @@
       matchCategories: ["js"],
       matchPackageNames: ["parcel"],
       matchPackagePrefixes: ["@parcel/"],
-      groupName: "Parcel",
+      groupName: "Parcel"
     },
 
     {


### PR DESCRIPTION
C'est pour pas que renovate propose d'update à Mysql 8.3 quand on a l'image dans le repo pour les tests
🤞 