### PR TITLE
Exclude react-router v7

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -47,6 +47,14 @@
     },
     {
       "matchCategories": ["js"],
+      "matchDepNames": [
+        "react-router",
+        "react-router-dom"
+      ],
+      allowedVersions: "< 7.0.0"
+    },
+    {
+      "matchCategories": ["js"],
       "matchDepNames": ["ts-jest"],
       allowedVersions: "!/^29\\.2\\.(4|5)$/"
     }


### PR DESCRIPTION
Pour éviter la suggestion pendant que le DS limite à la v6.