### PR TITLE
Exclude kotlinix-coroutines 1.10

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -11,6 +11,13 @@
       allowedVersions: "< 2.0.0"
     },
     {
+      "matchCategories": ["java"],
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.kotlinx/"
+      ],
+      allowedVersions: "< 1.10.0"
+    },
+    {
       "matchCategories": ["js"],
       "matchDepNames": [
         "styled-components"


### PR DESCRIPTION
Ça génère du metadata que kotlin <2.0.0 peut pas lire