### PR TITLE
Exclude java 21.0.9

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -4,8 +4,8 @@
 
   packageRules: [
     {
-      "allowedVersions": "< 22",
-      "description": "Limit Java version to 21. Kotlin doesn't support Java 25",
+      "allowedVersions": "<21.0.9  || >21.0.9 <22",
+      "description": "Limit Java version to <22 and exclude 21.0.9. Kotlin doesn't support Java 25",
       "matchDatasources": [
         "java-version"
       ],


### PR DESCRIPTION

Testé le range avec

https://jubianchi.github.io/semver-check/#/%3C21.0.9%20%20||%20%3E21.0.9%20%3C22/21.0.9%2B10.0.LTS