### PR TITLE
Change reviewersFromCodeOwners to false (QCTECH-3633)

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -19,7 +19,7 @@
     schedule: ["before 5am on tuesday"]
   },
   rebaseWhen: "conflicted",
-  reviewersFromCodeOwners: true,
+  reviewersFromCodeOwners: false,
   schedule: ["on sunday"],
   timezone: "America/Montreal",
 


### PR DESCRIPTION
C'est un truc que GitHub fait anyway, et je me demande si c'est pas ça qui prend de la mémoire de plus pour rien