### PR TITLE
Add exclusion for Kotlin packages under version 2.3.10

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -10,6 +10,14 @@
         "java-version"
       ],
     },
+   {
+      "matchCategories": ["java"],
+      "description": "CodeQL support"
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.kotlin/"
+      ],
+      allowedVersions: "< 2.3.10"
+    },
     {
       "matchCategories": ["js"],
       "matchDepNames": [


### PR DESCRIPTION
Added exclusion rule for Kotlin packages without CodeQL support.