### PR TITLE
Revert "Add 'github-tags' to matchManagers in exclusions for gradle/actions"

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -63,7 +63,7 @@
     },
     {
       "description": "v6 introduces a license change",
-      "matchManagers": ["github-actions", "github-tags"],
+      "matchManagers": ["github-actions"],
       "matchDepNames": [
         "/^gradle\\/actions"
       ],


### PR DESCRIPTION
Reverts kronostechnologies/renovate-config#275