### PR TITLE
Update allowedVersions to '<= 5' for gradle-actions

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -67,7 +67,7 @@
       "matchDepNames": [
         "/^gradle\\/actions"
       ],
-      allowedVersions: "< 6"
+      allowedVersions: "<= 5"
     }
   ]
 }


### PR DESCRIPTION
Faque finalement cette version là devrait fonctionner. On dirait qu'ils ont changé de quoi dans la gestion des versions pour github-actions et ça a fucké la comparaison
https://github.com/renovatebot/renovate/discussions/42692