### PR TITLE
QCTECH-5269 Try to fix minimum release age check for internal package

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -54,7 +54,7 @@
         "/^kronostechnologies\\//",
         "/^equisoft\\//"
       ],
-      minimumReleaseAge: "0 days",
+      minimumReleaseAge: null,
     },
 
     { "matchCategories": ["docker"], "addLabels": ["docker"], "prPriority": 5 },


### PR DESCRIPTION
QCTECH-5269

Root cause: config:recommended sets minimumReleaseAgeBehaviour to timestamp-required. Under this behaviour, if a release has no releaseTimestamp (as is the case for git-tags), Renovate treats the minimum-age check as unsatisfied — regardless of the configured age value, including "0 days".

Fix: Changed minimumReleaseAge: "0 days" → minimumReleaseAge: null for the internal Kronos/Equisoft package rule. Using null disables the check entirely for those packages, which was the original intent of "0 days" and avoids the timestamp-required deadlock.