### PR TITLE
Block phpunit < 13.2.0

### DIFF
--- a/exclusions.json5
+++ b/exclusions.json5
@@ -70,6 +70,14 @@
       allowedVersions: "< 13.2.0"
     },
     {
+      "matchCategories": ["php"],
+      "description": "Conflict with psalm not supporting sebastian/diff 9.x",
+      "matchDepNames": [
+        "sebastian/diff"
+      ],
+      allowedVersions: "< 9.0.0"
+    },
+    {
       "description": "v6 introduces a license change",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["gradle/actions"],

--- a/exclusions.json5
+++ b/exclusions.json5
@@ -62,6 +62,14 @@
       allowedVersions: "< 0.20.0"
     },
     {
+      "matchCategories": ["php"],
+      "description": "Conflict with psalm not supporting sebastian/diff 9.x",
+      "matchDepNames": [
+        "phpunit/phpunit"
+      ],
+      allowedVersions: "< 13.2.0"
+    },
+    {
       "description": "v6 introduces a license change",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["gradle/actions"],


### PR DESCRIPTION
Je vais bloquer phpunit 13.2 sur renovate parce que ça fait un conflit de dépendance avec vimeo/psalm qui supporte pas encore la version 9 de sebastian/diff